### PR TITLE
Make SDG data processing easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ This folder contains the SDG-based sustainability dashboard for analyzing 2000+ 
 - `sdg_dashboard.html` - Main dashboard interface
 - `start_sdg_server.bat` - Quick server startup script
 - `process_sdg_data.py` - Data processing utilities (optional)
+
+## Process SDG Data
+
+The `process_sdg_data.py` script converts the CSV data into a JSON file.
+Run it from the repository root:
+
+```bash
+python process_sdg_data.py [path/to/SDG-2000data.csv]
+```
+
+If no path is provided, the script uses the bundled `SDG-2000data.csv` file.

--- a/process_sdg_data.py
+++ b/process_sdg_data.py
@@ -1,11 +1,13 @@
-import pandas as pd
+import argparse
 import json
 import os
+import pandas as pd
 
-def process_sdg_csv():
+def process_sdg_csv(csv_path: str | None = None):
     try:
-        # Load the SDG CSV (corrected path)
-        csv_path = r'..\..\data\external\DATA_GoCarbonTracker\DATA GoCarbonTracker\Origin database\SDG-2000data.csv'
+        # Determine the CSV path. Use the CSV from this repository by default
+        if csv_path is None:
+            csv_path = os.path.join(os.path.dirname(__file__), 'SDG-2000data.csv')
         print(f"Loading CSV from: {csv_path}")
         
         df = pd.read_csv(csv_path)
@@ -80,4 +82,7 @@ def process_sdg_csv():
         traceback.print_exc()
 
 if __name__ == '__main__':
-    process_sdg_csv()
+    parser = argparse.ArgumentParser(description='Process SDG CSV into JSON')
+    parser.add_argument('csv_path', nargs='?', help='Optional path to SDG CSV file')
+    args = parser.parse_args()
+    process_sdg_csv(args.csv_path)


### PR DESCRIPTION
## Summary
- update `process_sdg_data.py` so the CSV defaults to the repo's `SDG-2000data.csv`
- allow an optional command line argument to override the path
- document usage of `process_sdg_data.py`

## Testing
- `python process_sdg_data.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b0b1c641483249d39132c8f0378d7